### PR TITLE
feat: add swirl app support

### DIFF
--- a/src/apps/swirl/config.ts
+++ b/src/apps/swirl/config.ts
@@ -1,0 +1,19 @@
+const config = {
+  // Package information
+  moduleId: '0x02d641d7b021b1cd7a2c361ac35b415ae8263be0641f9475ec32af4b9d8a8056',
+
+  // Module entries
+  nativePoolEntry: 'native_pool',
+
+  // Admin methods
+  changeBaseRewardFeeMethod: 'change_base_reward_fee',
+  changeMinStakeMethod: 'change_min_stake',
+  updateRewardsRevertMethod: 'update_rewards_revert',
+  updateRewardsThresholdMethod: 'update_rewards_threshold',
+
+  // Stake methods
+  stakeMethod: 'stake',
+  unstakeMethod: 'unstake',
+};
+
+export default config;

--- a/src/apps/swirl/decoder.ts
+++ b/src/apps/swirl/decoder.ts
@@ -1,0 +1,375 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { IotaSignTransactionInput, WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { IotaNetworks } from '@/types';
+
+import config from './config';
+import { TransactionSubType } from './types';
+
+type DecodeResult = {
+  txType: TransactionType;
+  type: TransactionSubType;
+  intentionData: any;
+};
+
+export class Decoder {
+  constructor(
+    private readonly input: IotaSignTransactionInput & {
+      network: IotaNetworks;
+      client: IotaClient;
+      account: WalletAccount;
+    },
+  ) {}
+
+  async decode(): Promise<DecodeResult> {
+    const { transaction } = this.input;
+
+    const txContent = await transaction.toJSON();
+    const tx = Transaction.from(txContent);
+
+    const txData = tx.getData();
+    this.txInputs = txData.inputs || [];
+
+    if (this.isChangeBaseRewardFeeTransaction(txData)) {
+      return this.decodeChangeBaseRewardFee(txData);
+    }
+    if (this.isChangeMinStakeTransaction(txData)) {
+      return this.decodeChangeMinStake(txData);
+    }
+    if (this.isStakeTransaction(txData)) {
+      return this.decodeStake(txData);
+    }
+    if (this.isUnstakeTransaction(txData)) {
+      return this.decodeUnstake(txData);
+    }
+    if (this.isUpdateRewardsRevertTransaction(txData)) {
+      return this.decodeUpdateRewardsRevert(txData);
+    }
+    if (this.isUpdateRewardsThresholdTransaction(txData)) {
+      return this.decodeUpdateRewardsThreshold(txData);
+    }
+
+    throw new Error('Unknown transaction type');
+  }
+
+  // Store transaction inputs for value extraction
+  private txInputs: any[] = [];
+
+  private isChangeBaseRewardFeeTransaction(txData: any): boolean {
+    return this.hasMoveCallWithTarget(
+      txData,
+      config.moduleId,
+      config.nativePoolEntry,
+      config.changeBaseRewardFeeMethod,
+    );
+  }
+
+  private isChangeMinStakeTransaction(txData: any): boolean {
+    return this.hasMoveCallWithTarget(txData, config.moduleId, config.nativePoolEntry, config.changeMinStakeMethod);
+  }
+
+  private isStakeTransaction(txData: any): boolean {
+    return this.hasMoveCallWithTarget(txData, config.moduleId, config.nativePoolEntry, config.stakeMethod);
+  }
+
+  private isUnstakeTransaction(txData: any): boolean {
+    return this.hasMoveCallWithTarget(txData, config.moduleId, config.nativePoolEntry, config.unstakeMethod);
+  }
+
+  private isUpdateRewardsRevertTransaction(txData: any): boolean {
+    return this.hasMoveCallWithTarget(
+      txData,
+      config.moduleId,
+      config.nativePoolEntry,
+      config.updateRewardsRevertMethod,
+    );
+  }
+
+  private isUpdateRewardsThresholdTransaction(txData: any): boolean {
+    return this.hasMoveCallWithTarget(
+      txData,
+      config.moduleId,
+      config.nativePoolEntry,
+      config.updateRewardsThresholdMethod,
+    );
+  }
+
+  // ========== DECODE METHODS ==========
+
+  private decodeChangeBaseRewardFee(txData: any): DecodeResult {
+    const moveCallCmd = this.getMoveCallCommand(
+      txData,
+      config.moduleId,
+      config.nativePoolEntry,
+      config.changeBaseRewardFeeMethod,
+    );
+
+    if (!moveCallCmd || !moveCallCmd.MoveCall) {
+      throw new Error('Invalid change_base_reward_fee transaction structure');
+    }
+
+    const { typeArguments, arguments: args } = moveCallCmd.MoveCall;
+
+    if (!typeArguments || typeArguments.length < 1 || !args || args.length < 1) {
+      throw new Error('Invalid change_base_reward_fee payload structure');
+    }
+
+    const [ownerCap] = typeArguments;
+
+    const value = this.extractU64Value(args[0]);
+
+    return {
+      txType: TransactionType.Staking,
+      type: TransactionSubType.CHANGE_BASE_REWARD_FEE,
+      intentionData: {
+        owner_cap: ownerCap,
+        value: value.toString(),
+      },
+    };
+  }
+
+  private decodeChangeMinStake(txData: any): DecodeResult {
+    const moveCallCmd = this.getMoveCallCommand(
+      txData,
+      config.moduleId,
+      config.nativePoolEntry,
+      config.changeMinStakeMethod,
+    );
+
+    if (!moveCallCmd || !moveCallCmd.MoveCall) {
+      throw new Error('Invalid change_min_stake transaction structure');
+    }
+
+    const { typeArguments, arguments: args } = moveCallCmd.MoveCall;
+
+    if (!typeArguments || typeArguments.length < 1 || !args || args.length < 1) {
+      throw new Error('Invalid change_min_stake payload structure');
+    }
+
+    const [ownerCap] = typeArguments;
+
+    const value = this.extractU64Value(args[0]);
+
+    return {
+      txType: TransactionType.Staking,
+      type: TransactionSubType.CHANGE_MIN_STAKE,
+      intentionData: {
+        owner_cap: ownerCap,
+        value: value.toString(),
+      },
+    };
+  }
+
+  private decodeStake(txData: any): DecodeResult {
+    const moveCallCmd = this.getMoveCallCommand(txData, config.moduleId, config.nativePoolEntry, config.stakeMethod);
+
+    if (!moveCallCmd || !moveCallCmd.MoveCall) {
+      throw new Error('Invalid stake transaction structure');
+    }
+
+    const { typeArguments } = moveCallCmd.MoveCall;
+
+    if (!typeArguments || typeArguments.length < 4) {
+      throw new Error('Invalid stake payload structure');
+    }
+
+    const [metadata, wrapper, coin, ctx] = typeArguments;
+
+    return {
+      txType: TransactionType.Staking,
+      type: TransactionSubType.STAKE,
+      intentionData: {
+        metadata,
+        wrapper,
+        coin,
+        ctx,
+      },
+    };
+  }
+
+  private decodeUnstake(txData: any): DecodeResult {
+    const moveCallCmd = this.getMoveCallCommand(txData, config.moduleId, config.nativePoolEntry, config.unstakeMethod);
+
+    if (!moveCallCmd || !moveCallCmd.MoveCall) {
+      throw new Error('Invalid unstake transaction structure');
+    }
+
+    const { typeArguments } = moveCallCmd.MoveCall;
+
+    if (!typeArguments || typeArguments.length < 4) {
+      throw new Error('Invalid unstake payload structure');
+    }
+
+    const [wrapper, metadata, cert, ctx] = typeArguments;
+
+    return {
+      txType: TransactionType.Staking,
+      type: TransactionSubType.UNSTAKE,
+      intentionData: {
+        wrapper,
+        metadata,
+        cert,
+        ctx,
+      },
+    };
+  }
+
+  private decodeUpdateRewardsRevert(txData: any): DecodeResult {
+    const moveCallCmd = this.getMoveCallCommand(
+      txData,
+      config.moduleId,
+      config.nativePoolEntry,
+      config.updateRewardsRevertMethod,
+    );
+
+    if (!moveCallCmd || !moveCallCmd.MoveCall) {
+      throw new Error('Invalid update_reward_reverts transaction structure');
+    }
+
+    const { typeArguments, arguments: args } = moveCallCmd.MoveCall;
+
+    if (!typeArguments || typeArguments.length < 1 || !args || args.length < 1) {
+      throw new Error('Invalid update_reward_reverts payload structure');
+    }
+
+    const [ownerCap] = typeArguments;
+
+    const value = this.extractU64Value(args[0]);
+
+    return {
+      txType: TransactionType.Staking,
+      type: TransactionSubType.UPDATE_REWARDS_REVERT,
+      intentionData: {
+        value: value.toString(),
+        owner_cap: ownerCap,
+      },
+    };
+  }
+
+  private decodeUpdateRewardsThreshold(txData: any): DecodeResult {
+    const moveCallCmd = this.getMoveCallCommand(
+      txData,
+      config.moduleId,
+      config.nativePoolEntry,
+      config.updateRewardsThresholdMethod,
+    );
+
+    if (!moveCallCmd || !moveCallCmd.MoveCall) {
+      throw new Error('Invalid update_reward_threshold transaction structure');
+    }
+
+    const { typeArguments, arguments: args } = moveCallCmd.MoveCall;
+
+    if (!typeArguments || typeArguments.length < 1 || !args || args.length < 1) {
+      throw new Error('Invalid update_reward_threshold payload structure');
+    }
+
+    const [ownerCap] = typeArguments;
+
+    const value = this.extractU64Value(args[0]);
+
+    return {
+      txType: TransactionType.Staking,
+      type: TransactionSubType.UPDATE_REWARDS_REVERT,
+      intentionData: {
+        owner_cap: ownerCap,
+        value: value.toString(),
+      },
+    };
+  }
+
+  // ========== HELPER METHODS ==========
+  private hasMoveCallWithTarget(txData: any, packageId: string, module: string, functionName: string): boolean {
+    if (!txData || !txData.commands) {
+      return false;
+    }
+
+    return txData.commands.some(
+      (cmd: any) =>
+        cmd.$kind === 'MoveCall' &&
+        cmd.MoveCall &&
+        cmd.MoveCall.package === packageId &&
+        cmd.MoveCall.module === module &&
+        cmd.MoveCall.function === functionName,
+    );
+  }
+
+  private getMoveCallCommand(txData: any, packageId: string, module: string, functionName: string): any {
+    if (!txData || !txData.commands) {
+      return null;
+    }
+
+    return txData.commands.find(
+      (cmd: any) =>
+        cmd.$kind === 'MoveCall' &&
+        cmd.MoveCall &&
+        cmd.MoveCall.package === packageId &&
+        cmd.MoveCall.module === module &&
+        cmd.MoveCall.function === functionName,
+    );
+  }
+
+  private extractU64Value(arg: any): bigint {
+    // Handle Input references
+    if (arg && arg.$kind === 'Input' && typeof arg.Input === 'number') {
+      const inputIndex = arg.Input;
+      if (this.txInputs && this.txInputs[inputIndex]) {
+        const input = this.txInputs[inputIndex];
+
+        // Handle Pure type with base64 bytes
+        if (input.$kind === 'Pure' && input.Pure && input.Pure.bytes) {
+          // Decode base64 bytes to get the actual value
+          const bytes = Buffer.from(input.Pure.bytes, 'base64');
+          // Convert bytes to bigint (little-endian)
+          let value = BigInt(0);
+          for (let i = 0; i < bytes.length; i++) {
+            // eslint-disable-next-line no-bitwise
+            value += BigInt(bytes[i]) << BigInt(i * 8);
+          }
+          return value;
+        }
+
+        // Handle other input types
+        if (input.type === 'pure' && input.value !== undefined) {
+          return BigInt(input.value);
+        }
+        if (typeof input === 'number' || typeof input === 'string') {
+          return BigInt(input);
+        }
+      }
+      return BigInt(inputIndex);
+    }
+
+    // Handle direct Pure values
+    if (arg && arg.$kind === 'Pure') {
+      if (arg.Pure && typeof arg.Pure === 'string') {
+        return BigInt(arg.Pure);
+      }
+      if (arg.Pure && typeof arg.Pure === 'number') {
+        return BigInt(arg.Pure);
+      }
+      if (Array.isArray(arg.Pure)) {
+        // Handle byte array representation
+        // eslint-disable-next-line no-bitwise
+        const value = arg.Pure.reduce(
+          (acc: bigint, byte: number, index: number) => acc + (BigInt(byte) << BigInt(index * 8)),
+          BigInt(0),
+        );
+        return value;
+      }
+      return BigInt(arg.Pure);
+    }
+
+    if (typeof arg === 'bigint') {
+      return arg;
+    }
+
+    if (typeof arg === 'number' || typeof arg === 'string') {
+      return BigInt(arg);
+    }
+
+    return BigInt(0);
+  }
+}

--- a/src/apps/swirl/helper.ts
+++ b/src/apps/swirl/helper.ts
@@ -1,0 +1,94 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { IotaSignTransactionInput, WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { MSafeAppHelper } from '@/apps/interface';
+import { IotaNetworks } from '@/types';
+
+import { Decoder } from './decoder';
+import { ChangeBaseRewardFeeIntention, ChangeBaseRewardFeeIntentionData } from './intentions/changeBaseRewardFee';
+import { ChangeMinStakeIntention, ChangeMinStakeIntentionData } from './intentions/changeMinStake';
+import { StakeIntention, StakeIntentionData } from './intentions/stake';
+import { UnstakeIntention, UnstakeIntentionData } from './intentions/unstake';
+import { UpdateRewardsRevertIntention, UpdateRewardsRevertIntentionData } from './intentions/updateRewardsRevert';
+import {
+  UpdateRewardsThresholdIntention,
+  UpdateRewardsThresholdIntentionData,
+} from './intentions/updateRewardsThreshold';
+import { TransactionSubType } from './types';
+
+export type SwirlIntention =
+  | ChangeBaseRewardFeeIntention
+  | ChangeMinStakeIntention
+  | StakeIntention
+  | UnstakeIntention
+  | UpdateRewardsRevertIntention
+  | UpdateRewardsThresholdIntention;
+
+export type SwirlIntentionData =
+  | ChangeBaseRewardFeeIntentionData
+  | ChangeMinStakeIntentionData
+  | StakeIntentionData
+  | UnstakeIntentionData
+  | UpdateRewardsRevertIntentionData
+  | UpdateRewardsThresholdIntentionData;
+
+export class SwirlAppHelper implements MSafeAppHelper<SwirlIntentionData> {
+  application = 'Swirl';
+
+  async deserialize(
+    input: IotaSignTransactionInput & {
+      network: IotaNetworks;
+      client: IotaClient;
+      account: WalletAccount;
+    },
+  ): Promise<{ txType: TransactionType; txSubType: string; intentionData: SwirlIntentionData }> {
+    const decoder = new Decoder(input);
+    const result = await decoder.decode();
+
+    return {
+      txType: result.txType,
+      txSubType: result.type,
+      intentionData: result.intentionData,
+    };
+  }
+
+  async build(input: {
+    network: string;
+    txType: TransactionType;
+    txSubType: string;
+    intentionData: SwirlIntentionData;
+    client: IotaClient;
+    account: WalletAccount;
+  }): Promise<Transaction> {
+    const { client, account, txSubType, intentionData } = input;
+
+    let intention: SwirlIntention;
+
+    switch (txSubType) {
+      case TransactionSubType.CHANGE_BASE_REWARD_FEE:
+        intention = ChangeBaseRewardFeeIntention.fromData(intentionData as ChangeBaseRewardFeeIntentionData);
+        break;
+      case TransactionSubType.CHANGE_MIN_STAKE:
+        intention = ChangeMinStakeIntention.fromData(intentionData as ChangeMinStakeIntentionData);
+        break;
+      case TransactionSubType.STAKE:
+        intention = StakeIntention.fromData(intentionData as StakeIntentionData);
+        break;
+      case TransactionSubType.UNSTAKE:
+        intention = UnstakeIntention.fromData(intentionData as UnstakeIntentionData);
+        break;
+      case TransactionSubType.UPDATE_REWARDS_REVERT:
+        intention = UpdateRewardsRevertIntention.fromData(intentionData as UpdateRewardsRevertIntentionData);
+        break;
+      case TransactionSubType.UPDATE_REWARDS_THRESHOLD:
+        intention = UpdateRewardsThresholdIntention.fromData(intentionData as UpdateRewardsThresholdIntentionData);
+        break;
+      default:
+        throw new Error(`Unsupported transaction subtype: ${txSubType}`);
+    }
+
+    return intention.build({ client, account });
+  }
+}

--- a/src/apps/swirl/intentions/changeBaseRewardFee.ts
+++ b/src/apps/swirl/intentions/changeBaseRewardFee.ts
@@ -33,8 +33,7 @@ export class ChangeBaseRewardFeeIntention extends BaseIntention<ChangeBaseReward
       package: config.moduleId,
       module: config.nativePoolEntry,
       function: config.changeBaseRewardFeeMethod,
-      typeArguments: [this.data.owner_cap],
-      arguments: [transaction.pure.u64(this.data.value)],
+      arguments: [transaction.object(this.data.owner_cap), transaction.pure.u64(this.data.value)],
     });
 
     return transaction;

--- a/src/apps/swirl/intentions/changeBaseRewardFee.ts
+++ b/src/apps/swirl/intentions/changeBaseRewardFee.ts
@@ -1,0 +1,46 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { BaseIntention } from '@/apps/interface';
+
+import config from '../config';
+import { TransactionSubType } from '../types';
+
+export interface ChangeBaseRewardFeeIntentionData {
+  owner_cap: string;
+  value: string;
+}
+
+export class ChangeBaseRewardFeeIntention extends BaseIntention<ChangeBaseRewardFeeIntentionData> {
+  txType: TransactionType.Staking;
+
+  txSubType: TransactionSubType.CHANGE_BASE_REWARD_FEE;
+
+  constructor(public readonly data: ChangeBaseRewardFeeIntentionData) {
+    super(data);
+  }
+
+  async build(input: { client: IotaClient; account: WalletAccount }): Promise<Transaction> {
+    const { client, account } = input;
+
+    const transaction = new Transaction();
+
+    transaction.setSender(account.address);
+
+    transaction.moveCall({
+      package: config.moduleId,
+      module: config.nativePoolEntry,
+      function: config.changeBaseRewardFeeMethod,
+      typeArguments: [this.data.owner_cap],
+      arguments: [transaction.pure.u64(this.data.value)],
+    });
+
+    return transaction;
+  }
+
+  static fromData(data: ChangeBaseRewardFeeIntentionData) {
+    return new ChangeBaseRewardFeeIntention(data);
+  }
+}

--- a/src/apps/swirl/intentions/changeMinStake.ts
+++ b/src/apps/swirl/intentions/changeMinStake.ts
@@ -1,0 +1,46 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { BaseIntention } from '@/apps/interface';
+
+import config from '../config';
+import { TransactionSubType } from '../types';
+
+export interface ChangeMinStakeIntentionData {
+  owner_cap: string;
+  value: string;
+}
+
+export class ChangeMinStakeIntention extends BaseIntention<ChangeMinStakeIntentionData> {
+  txType: TransactionType.Staking;
+
+  txSubType: TransactionSubType.CHANGE_MIN_STAKE;
+
+  constructor(public readonly data: ChangeMinStakeIntentionData) {
+    super(data);
+  }
+
+  async build(input: { client: IotaClient; account: WalletAccount }): Promise<Transaction> {
+    const { client, account } = input;
+
+    const transaction = new Transaction();
+
+    transaction.setSender(account.address);
+
+    transaction.moveCall({
+      package: config.moduleId,
+      module: config.nativePoolEntry,
+      function: config.changeMinStakeMethod,
+      typeArguments: [this.data.owner_cap],
+      arguments: [transaction.pure.u64(this.data.value)],
+    });
+
+    return transaction;
+  }
+
+  static fromData(data: ChangeMinStakeIntentionData) {
+    return new ChangeMinStakeIntention(data);
+  }
+}

--- a/src/apps/swirl/intentions/changeMinStake.ts
+++ b/src/apps/swirl/intentions/changeMinStake.ts
@@ -33,8 +33,7 @@ export class ChangeMinStakeIntention extends BaseIntention<ChangeMinStakeIntenti
       package: config.moduleId,
       module: config.nativePoolEntry,
       function: config.changeMinStakeMethod,
-      typeArguments: [this.data.owner_cap],
-      arguments: [transaction.pure.u64(this.data.value)],
+      arguments: [transaction.object(this.data.owner_cap), transaction.pure.u64(this.data.value)],
     });
 
     return transaction;

--- a/src/apps/swirl/intentions/stake.ts
+++ b/src/apps/swirl/intentions/stake.ts
@@ -1,0 +1,52 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { BaseIntention } from '@/apps/interface';
+
+import config from '../config';
+import { TransactionSubType } from '../types';
+
+export interface StakeIntentionData {
+  metadata: string;
+  wrapper: string;
+  coin: string;
+  ctx: string;
+}
+
+export class StakeIntention extends BaseIntention<StakeIntentionData> {
+  txType: TransactionType.Staking;
+
+  txSubType: TransactionSubType.STAKE;
+
+  constructor(public readonly data: StakeIntentionData) {
+    super(data);
+  }
+
+  async build(input: { client: IotaClient; account: WalletAccount }): Promise<Transaction> {
+    const { client, account } = input;
+
+    const transaction = new Transaction();
+
+    transaction.setSender(account.address);
+
+    transaction.moveCall({
+      package: config.moduleId,
+      module: config.nativePoolEntry,
+      function: config.stakeMethod,
+      typeArguments: [
+        this.data.metadata,
+        this.data.wrapper,
+        this.data.coin,
+        this.data.ctx,
+      ],
+    });
+
+    return transaction;
+  }
+
+  static fromData(data: StakeIntentionData) {
+    return new StakeIntention(data);
+  }
+}

--- a/src/apps/swirl/intentions/stake.ts
+++ b/src/apps/swirl/intentions/stake.ts
@@ -35,11 +35,11 @@ export class StakeIntention extends BaseIntention<StakeIntentionData> {
       package: config.moduleId,
       module: config.nativePoolEntry,
       function: config.stakeMethod,
-      typeArguments: [
-        this.data.metadata,
-        this.data.wrapper,
-        this.data.coin,
-        this.data.ctx,
+      arguments: [
+        transaction.object(this.data.metadata),
+        transaction.object(this.data.wrapper),
+        transaction.object(this.data.coin),
+        transaction.object(this.data.ctx),
       ],
     });
 

--- a/src/apps/swirl/intentions/unstake.ts
+++ b/src/apps/swirl/intentions/unstake.ts
@@ -35,7 +35,12 @@ export class UnstakeIntention extends BaseIntention<UnstakeIntentionData> {
       package: config.moduleId,
       module: config.nativePoolEntry,
       function: config.unstakeMethod,
-      typeArguments: [this.data.wrapper, this.data.metadata, this.data.cert, this.data.ctx],
+      arguments: [
+        transaction.object(this.data.wrapper),
+        transaction.object(this.data.metadata),
+        transaction.object(this.data.cert),
+        transaction.object(this.data.ctx),
+      ],
     });
 
     return transaction;

--- a/src/apps/swirl/intentions/unstake.ts
+++ b/src/apps/swirl/intentions/unstake.ts
@@ -1,0 +1,47 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { BaseIntention } from '@/apps/interface';
+
+import config from '../config';
+import { TransactionSubType } from '../types';
+
+export interface UnstakeIntentionData {
+  wrapper: string;
+  metadata: string;
+  cert: string;
+  ctx: string;
+}
+
+export class UnstakeIntention extends BaseIntention<UnstakeIntentionData> {
+  txType: TransactionType.Staking;
+
+  txSubType: TransactionSubType.UNSTAKE;
+
+  constructor(public readonly data: UnstakeIntentionData) {
+    super(data);
+  }
+
+  async build(input: { client: IotaClient; account: WalletAccount }): Promise<Transaction> {
+    const { client, account } = input;
+
+    const transaction = new Transaction();
+
+    transaction.setSender(account.address);
+
+    transaction.moveCall({
+      package: config.moduleId,
+      module: config.nativePoolEntry,
+      function: config.unstakeMethod,
+      typeArguments: [this.data.wrapper, this.data.metadata, this.data.cert, this.data.ctx],
+    });
+
+    return transaction;
+  }
+
+  static fromData(data: UnstakeIntentionData) {
+    return new UnstakeIntention(data);
+  }
+}

--- a/src/apps/swirl/intentions/updateRewardsRevert.ts
+++ b/src/apps/swirl/intentions/updateRewardsRevert.ts
@@ -33,8 +33,10 @@ export class UpdateRewardsRevertIntention extends BaseIntention<UpdateRewardsRev
       package: config.moduleId,
       module: config.nativePoolEntry,
       function: config.updateRewardsRevertMethod,
-      typeArguments: [this.data.owner_cap],
-      arguments: [transaction.pure.u64(this.data.value)],
+      arguments: [
+        transaction.pure.u64(this.data.value),
+        transaction.object(this.data.owner_cap),
+      ],
     });
 
     return transaction;

--- a/src/apps/swirl/intentions/updateRewardsRevert.ts
+++ b/src/apps/swirl/intentions/updateRewardsRevert.ts
@@ -1,0 +1,46 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { BaseIntention } from '@/apps/interface';
+
+import config from '../config';
+import { TransactionSubType } from '../types';
+
+export interface UpdateRewardsRevertIntentionData {
+  value: string;
+  owner_cap: string;
+}
+
+export class UpdateRewardsRevertIntention extends BaseIntention<UpdateRewardsRevertIntentionData> {
+  txType: TransactionType.Staking;
+
+  txSubType: TransactionSubType.UPDATE_REWARDS_REVERT;
+
+  constructor(public readonly data: UpdateRewardsRevertIntentionData) {
+    super(data);
+  }
+
+  async build(input: { client: IotaClient; account: WalletAccount }): Promise<Transaction> {
+    const { client, account } = input;
+
+    const transaction = new Transaction();
+
+    transaction.setSender(account.address);
+
+    transaction.moveCall({
+      package: config.moduleId,
+      module: config.nativePoolEntry,
+      function: config.updateRewardsRevertMethod,
+      typeArguments: [this.data.owner_cap],
+      arguments: [transaction.pure.u64(this.data.value)],
+    });
+
+    return transaction;
+  }
+
+  static fromData(data: UpdateRewardsRevertIntentionData) {
+    return new UpdateRewardsRevertIntention(data);
+  }
+}

--- a/src/apps/swirl/intentions/updateRewardsThreshold.ts
+++ b/src/apps/swirl/intentions/updateRewardsThreshold.ts
@@ -1,0 +1,46 @@
+import { IotaClient } from '@iota/iota-sdk/client';
+import { Transaction } from '@iota/iota-sdk/transactions';
+import { WalletAccount } from '@iota/wallet-standard';
+import { TransactionType } from '@msafe/iota-utils';
+
+import { BaseIntention } from '@/apps/interface';
+
+import config from '../config';
+import { TransactionSubType } from '../types';
+
+export interface UpdateRewardsThresholdIntentionData {
+  owner_cap: string;
+  value: string;
+}
+
+export class UpdateRewardsThresholdIntention extends BaseIntention<UpdateRewardsThresholdIntentionData> {
+  txType: TransactionType.Staking;
+
+  txSubType: TransactionSubType.UPDATE_REWARDS_THRESHOLD;
+
+  constructor(public readonly data: UpdateRewardsThresholdIntentionData) {
+    super(data);
+  }
+
+  async build(input: { client: IotaClient; account: WalletAccount }): Promise<Transaction> {
+    const { client, account } = input;
+
+    const transaction = new Transaction();
+
+    transaction.setSender(account.address);
+
+    transaction.moveCall({
+      package: config.moduleId,
+      module: config.nativePoolEntry,
+      function: config.updateRewardsThresholdMethod,
+      typeArguments: [this.data.owner_cap],
+      arguments: [transaction.pure.u64(this.data.value)],
+    });
+
+    return transaction;
+  }
+
+  static fromData(data: UpdateRewardsThresholdIntentionData) {
+    return new UpdateRewardsThresholdIntention(data);
+  }
+}

--- a/src/apps/swirl/intentions/updateRewardsThreshold.ts
+++ b/src/apps/swirl/intentions/updateRewardsThreshold.ts
@@ -33,8 +33,7 @@ export class UpdateRewardsThresholdIntention extends BaseIntention<UpdateRewards
       package: config.moduleId,
       module: config.nativePoolEntry,
       function: config.updateRewardsThresholdMethod,
-      typeArguments: [this.data.owner_cap],
-      arguments: [transaction.pure.u64(this.data.value)],
+      arguments: [transaction.object(this.data.owner_cap), transaction.pure.u64(this.data.value)],
     });
 
     return transaction;

--- a/src/apps/swirl/types.ts
+++ b/src/apps/swirl/types.ts
@@ -1,0 +1,8 @@
+export enum TransactionSubType {
+  CHANGE_BASE_REWARD_FEE = 'change-base-reward-fee',
+  CHANGE_MIN_STAKE = 'change-min-stake',
+  UPDATE_REWARDS_REVERT = 'update-reward-revert',
+  UPDATE_REWARDS_THRESHOLD = 'update-reward-threshold',
+  STAKE = 'stake',
+  UNSTAKE = 'unstake',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { CoreHelper } from '@/apps/msafe-core/helper';
 import { PlainTransactionHelper } from '@/apps/plain-transaction/helper';
 import { PoolsAppHelper } from '@/apps/pools/helper';
 import { MSafeApps } from '@/apps/registry';
+import { SwirlAppHelper } from '@/apps/swirl/helper';
 
 import { VirtueHelper } from './apps/virtue/helper';
 
@@ -10,4 +11,5 @@ export const appHelpers = new MSafeApps([
   new PlainTransactionHelper(),
   new PoolsAppHelper(),
   new VirtueHelper(),
+  new SwirlAppHelper(),
 ]);

--- a/test/swirl.test.ts
+++ b/test/swirl.test.ts
@@ -23,7 +23,7 @@ describe('Swirl Wallet', () => {
   describe('Build/Serialize', () => {
     it('Change Base Reward Fee transaction build', async () => {
       const intentionData: ChangeBaseRewardFeeIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 
@@ -44,7 +44,7 @@ describe('Swirl Wallet', () => {
 
     it('Change Base Reward Fee intention serialization', () => {
       const intentionData: ChangeBaseRewardFeeIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 
@@ -58,7 +58,7 @@ describe('Swirl Wallet', () => {
 
     it('Change MinStake transaction build', async () => {
       const intentionData: ChangeMinStakeIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 
@@ -79,7 +79,7 @@ describe('Swirl Wallet', () => {
 
     it('Change MinStake intention serialization', () => {
       const intentionData: ChangeMinStakeIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 
@@ -93,10 +93,10 @@ describe('Swirl Wallet', () => {
 
     it('Stake transaction build', async () => {
       const intentionData: StakeIntentionData = {
-        metadata: '',
-        wrapper: '',
-        coin: '',
-        ctx: '',
+        metadata: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        wrapper: '0x0000000000000000000000000000000000000000000000000000000000000002',
+        coin: '0x0000000000000000000000000000000000000000000000000000000000000003',
+        ctx: '0x0000000000000000000000000000000000000000000000000000000000000004',
       };
 
       const res = await appHelper.build({
@@ -116,10 +116,10 @@ describe('Swirl Wallet', () => {
 
     it('Stake intention serialization', () => {
       const intentionData: StakeIntentionData = {
-        metadata: '',
-        wrapper: '',
-        coin: '',
-        ctx: '',
+        metadata: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        wrapper: '0x0000000000000000000000000000000000000000000000000000000000000002',
+        coin: '0x0000000000000000000000000000000000000000000000000000000000000003',
+        ctx: '0x0000000000000000000000000000000000000000000000000000000000000004',
       };
 
       const intention = StakeIntention.fromData(intentionData);
@@ -134,10 +134,10 @@ describe('Swirl Wallet', () => {
 
     it('Unstake transaction build', async () => {
       const intentionData: UnstakeIntentionData = {
-        metadata: '',
-        wrapper: '',
-        cert: '',
-        ctx: '',
+        metadata: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        wrapper: '0x0000000000000000000000000000000000000000000000000000000000000002',
+        cert: '0x0000000000000000000000000000000000000000000000000000000000000003',
+        ctx: '0x0000000000000000000000000000000000000000000000000000000000000004',
       };
 
       const res = await appHelper.build({
@@ -157,10 +157,10 @@ describe('Swirl Wallet', () => {
 
     it('Unstake intention serialization', () => {
       const intentionData: UnstakeIntentionData = {
-        metadata: '',
-        wrapper: '',
-        cert: '',
-        ctx: '',
+        metadata: '0x0000000000000000000000000000000000000000000000000000000000000001',
+        wrapper: '0x0000000000000000000000000000000000000000000000000000000000000002',
+        cert: '0x0000000000000000000000000000000000000000000000000000000000000003',
+        ctx: '0x0000000000000000000000000000000000000000000000000000000000000004',
       };
 
       const intention = UnstakeIntention.fromData(intentionData);
@@ -175,7 +175,7 @@ describe('Swirl Wallet', () => {
 
     it('Update Rewards Revert transaction build', async () => {
       const intentionData: UpdateRewardsRevertIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 
@@ -196,7 +196,7 @@ describe('Swirl Wallet', () => {
 
     it('Update Rewards Revert intention serialization', () => {
       const intentionData: UpdateRewardsRevertIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 
@@ -210,7 +210,7 @@ describe('Swirl Wallet', () => {
 
     it('Update Rewards Threshold transaction build', async () => {
       const intentionData: UpdateRewardsThresholdIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 
@@ -231,7 +231,7 @@ describe('Swirl Wallet', () => {
 
     it('Update Rewards Threshold intention serialization', () => {
       const intentionData: UpdateRewardsThresholdIntentionData = {
-        owner_cap: '',
+        owner_cap: '0x0000000000000000000000000000000000000000000000000000000000000001',
         value: '1000000000', // 1 IOTA
       };
 

--- a/test/swirl.test.ts
+++ b/test/swirl.test.ts
@@ -1,0 +1,246 @@
+import { TransactionType } from '@msafe/iota-utils';
+import { ChangeBaseRewardFeeIntention, ChangeBaseRewardFeeIntentionData } from '@/apps/swirl/intentions/changeBaseRewardFee';
+import { ChangeMinStakeIntention, ChangeMinStakeIntentionData } from '@/apps/swirl/intentions/changeMinStake';
+import { StakeIntention, StakeIntentionData } from '@/apps/swirl/intentions/stake';
+import { UnstakeIntention, UnstakeIntentionData } from '@/apps/swirl/intentions/unstake';
+import { UpdateRewardsRevertIntention, UpdateRewardsRevertIntentionData } from '@/apps/swirl/intentions/updateRewardsRevert';
+import {
+  UpdateRewardsThresholdIntention,
+  UpdateRewardsThresholdIntentionData,
+} from '@/apps/swirl/intentions/updateRewardsThreshold';
+import { TransactionSubType } from '@/apps/swirl/types';
+import { appHelpers } from '@/index';
+
+import { Account, Client } from './config';
+
+describe('Swirl Wallet', () => {
+  const appHelper = appHelpers.getAppHelper('Swirl');
+
+  it('Should get correct app helper', () => {
+    expect(appHelper.application).toBe('Swirl');
+  });
+
+  describe('Build/Serialize', () => {
+    it('Change Base Reward Fee transaction build', async () => {
+      const intentionData: ChangeBaseRewardFeeIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const res = await appHelper.build({
+        network: 'iota:testnet',
+        txType: TransactionType.Staking,
+        txSubType: TransactionSubType.CHANGE_BASE_REWARD_FEE,
+        client: Client,
+        account: Account,
+        intentionData,
+      });
+
+      const txData = res.getData();
+      expect(txData.sender).toBe(Account.address);
+      expect(txData.commands).toHaveLength(1);
+      expect(txData.commands[0].$kind).toBe('MoveCall');
+    });
+
+    it('Change Base Reward Fee intention serialization', () => {
+      const intentionData: ChangeBaseRewardFeeIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const intention = ChangeBaseRewardFeeIntention.fromData(intentionData);
+      const serialized = intention.serialize();
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.value).toBe(intentionData.value);
+      expect(parsed.owner_cap).toBe(intentionData.owner_cap);
+    });
+
+    it('Change MinStake transaction build', async () => {
+      const intentionData: ChangeMinStakeIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const res = await appHelper.build({
+        network: 'iota:testnet',
+        txType: TransactionType.Staking,
+        txSubType: TransactionSubType.CHANGE_MIN_STAKE,
+        client: Client,
+        account: Account,
+        intentionData,
+      });
+
+      const txData = res.getData();
+      expect(txData.sender).toBe(Account.address);
+      expect(txData.commands).toHaveLength(1);
+      expect(txData.commands[0].$kind).toBe('MoveCall');
+    });
+
+    it('Change MinStake intention serialization', () => {
+      const intentionData: ChangeMinStakeIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const intention = ChangeMinStakeIntention.fromData(intentionData);
+      const serialized = intention.serialize();
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.value).toBe(intentionData.value);
+      expect(parsed.owner_cap).toBe(intentionData.owner_cap);
+    });
+
+    it('Stake transaction build', async () => {
+      const intentionData: StakeIntentionData = {
+        metadata: '',
+        wrapper: '',
+        coin: '',
+        ctx: '',
+      };
+
+      const res = await appHelper.build({
+        network: 'iota:testnet',
+        txType: TransactionType.Staking,
+        txSubType: TransactionSubType.STAKE,
+        client: Client,
+        account: Account,
+        intentionData,
+      });
+
+      const txData = res.getData();
+      expect(txData.sender).toBe(Account.address);
+      expect(txData.commands).toHaveLength(1);
+      expect(txData.commands[0].$kind).toBe('MoveCall');
+    });
+
+    it('Stake intention serialization', () => {
+      const intentionData: StakeIntentionData = {
+        metadata: '',
+        wrapper: '',
+        coin: '',
+        ctx: '',
+      };
+
+      const intention = StakeIntention.fromData(intentionData);
+      const serialized = intention.serialize();
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.metadata).toBe(intentionData.metadata);
+      expect(parsed.wrapper).toBe(intentionData.wrapper);
+      expect(parsed.coin).toBe(intentionData.coin);
+      expect(parsed.ctx).toBe(intentionData.ctx);
+    });
+
+    it('Unstake transaction build', async () => {
+      const intentionData: UnstakeIntentionData = {
+        metadata: '',
+        wrapper: '',
+        cert: '',
+        ctx: '',
+      };
+
+      const res = await appHelper.build({
+        network: 'iota:testnet',
+        txType: TransactionType.Staking,
+        txSubType: TransactionSubType.UNSTAKE,
+        client: Client,
+        account: Account,
+        intentionData,
+      });
+
+      const txData = res.getData();
+      expect(txData.sender).toBe(Account.address);
+      expect(txData.commands).toHaveLength(1);
+      expect(txData.commands[0].$kind).toBe('MoveCall');
+    });
+
+    it('Unstake intention serialization', () => {
+      const intentionData: UnstakeIntentionData = {
+        metadata: '',
+        wrapper: '',
+        cert: '',
+        ctx: '',
+      };
+
+      const intention = UnstakeIntention.fromData(intentionData);
+      const serialized = intention.serialize();
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.metadata).toBe(intentionData.metadata);
+      expect(parsed.wrapper).toBe(intentionData.wrapper);
+      expect(parsed.cert).toBe(intentionData.cert);
+      expect(parsed.ctx).toBe(intentionData.ctx);
+    });
+
+    it('Update Rewards Revert transaction build', async () => {
+      const intentionData: UpdateRewardsRevertIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const res = await appHelper.build({
+        network: 'iota:testnet',
+        txType: TransactionType.Staking,
+        txSubType: TransactionSubType.UPDATE_REWARDS_REVERT,
+        client: Client,
+        account: Account,
+        intentionData,
+      });
+
+      const txData = res.getData();
+      expect(txData.sender).toBe(Account.address);
+      expect(txData.commands).toHaveLength(1);
+      expect(txData.commands[0].$kind).toBe('MoveCall');
+    });
+
+    it('Update Rewards Revert intention serialization', () => {
+      const intentionData: UpdateRewardsRevertIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const intention = UpdateRewardsRevertIntention.fromData(intentionData);
+      const serialized = intention.serialize();
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.value).toBe(intentionData.value);
+      expect(parsed.owner_cap).toBe(intentionData.owner_cap);
+    });
+
+    it('Update Rewards Threshold transaction build', async () => {
+      const intentionData: UpdateRewardsThresholdIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const res = await appHelper.build({
+        network: 'iota:testnet',
+        txType: TransactionType.Staking,
+        txSubType: TransactionSubType.UPDATE_REWARDS_THRESHOLD,
+        client: Client,
+        account: Account,
+        intentionData,
+      });
+
+      const txData = res.getData();
+      expect(txData.sender).toBe(Account.address);
+      expect(txData.commands).toHaveLength(1);
+      expect(txData.commands[0].$kind).toBe('MoveCall');
+    });
+
+    it('Update Rewards Threshold intention serialization', () => {
+      const intentionData: UpdateRewardsThresholdIntentionData = {
+        owner_cap: '',
+        value: '1000000000', // 1 IOTA
+      };
+
+      const intention = UpdateRewardsThresholdIntention.fromData(intentionData);
+      const serialized = intention.serialize();
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed.value).toBe(intentionData.value);
+      expect(parsed.owner_cap).toBe(intentionData.owner_cap);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds Swirl Liquid Staking protocol (https://swirlstake.com/app/) implementation with transaction decoders and test coverage.

Support was added to 
* Admin functions (change_min_stake, change_base_reward_fee, update_rewards_threshold, update_rewards_revert)
* stake/unstake calls